### PR TITLE
Feature - Add get_position(s) method to return player positions

### DIFF
--- a/docs/classes/position.rst
+++ b/docs/classes/position.rst
@@ -1,0 +1,53 @@
+Gameweek
+================
+
+Information for the :class:`Position <fpl.models.position.Position>` is taken from e.g. the following endpoints:
+  https://fantasy.premierleague.com/api/bootstrap-static/
+
+
+An example of part of what information a :class:`Position <fpl.models.position.Position>` contains is shown below:
+
+.. code-block:: javascript
+
+  {
+    "id": 1,
+    "plural_name": "Goalkeepers",
+    "plural_name_short": "GKP",
+    "singular_name": "Goalkeeper",
+    "singular_name_short": "GKP",
+    "squad_select": 2,
+    "squad_min_select": null,
+    "squad_max_select": null,
+    "squad_min_play": 1,
+    "squad_max_play": 1,
+    "ui_shirt_specific": true,
+    "sub_positions_locked": [
+      12
+    ],
+    "element_count": 64
+    }
+
+Basic usage:
+
+.. code-block:: python
+
+  from fpl import FPL
+  import aiohttp
+  import asyncio
+  
+  async def main():
+      async with aiohttp.ClientSession() as session:
+          fpl = FPL(session)
+          position = await fpl.get_position(1)
+      print(position)
+
+  # Python 3.7+
+  asyncio.run(main())
+  ...
+  # Python 3.6
+  loop = asyncio.get_event_loop()
+  loop.run_until_complete(main())
+  # Goalkeeper
+
+.. autoclass:: fpl.models.position.Position
+   :members:

--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -323,7 +323,7 @@ class FPL:
 
         try:
             position = next(position for position in positions.values()
-                          if position["id"] == position)
+                          if position["id"] == position_id)
         except StopIteration:
             raise ValueError(f"Position with ID {position_id} not found")
 
@@ -354,7 +354,7 @@ class FPL:
             positions = list(positions.values())
 
         if not return_json:
-            positions = [Position(positions) for position in positions]
+            positions = [Position(position) for position in positions]
 
         return positions
 

--- a/fpl/models/__init__.py
+++ b/fpl/models/__init__.py
@@ -3,8 +3,9 @@ from .fixture import Fixture
 from .gameweek import Gameweek
 from .h2h_league import H2HLeague
 from .player import Player
+from .position import Position
 from .team import Team
 from .user import User
 
-__all__ = ("ClassicLeague", "Fixture", "Gameweek", "H2HLeague", "Player",
-           "Team", "User")
+__all__ = ("ClassicLeague", "Fixture", "Gameweek", "H2HLeague", "Player",   
+           "Position", "Team", "User")

--- a/fpl/models/position.py
+++ b/fpl/models/position.py
@@ -1,0 +1,9 @@
+class Postion():
+    """A class representing a player's position in Fantasy Premier League."""
+
+    def __init__(self, player_information):
+        for k, v in player_information.items():
+            setattr(self, k, v)
+
+    def __str__(self):
+        return f"{self.singular_name}"

--- a/fpl/models/position.py
+++ b/fpl/models/position.py
@@ -1,8 +1,8 @@
-class Postion():
+class Position():
     """A class representing a player's position in Fantasy Premier League."""
 
-    def __init__(self, player_information):
-        for k, v in player_information.items():
+    def __init__(self, position_information):
+        for k, v in position_information.items():
             setattr(self, k, v)
 
     def __str__(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,13 +4,14 @@ import pytest_asyncio
 import os
 
 from fpl import FPL
-from fpl.models import Fixture, H2HLeague, User, ClassicLeague, Team, Gameweek
+from fpl.models import Fixture, H2HLeague, User, ClassicLeague, Team, Gameweek, Position
 from tests.test_classic_league import classic_league_data
 from tests.test_fixture import fixture_data
 from tests.test_h2h_league import h2h_league_data
 from tests.test_team import team_data
 from tests.test_user import user_data
 from tests.test_gameweek import gameweek_data
+from tests.test_position import position_data
 
 try:
     from.temp_env_var import TEMP_ENV_VARS, ENV_VARS_TO_SUSPEND
@@ -54,6 +55,11 @@ async def gameweek():
 @pytest_asyncio.fixture()
 async def player(fpl):
     yield await fpl.get_player(345, include_summary=True)
+
+
+@pytest_asyncio.fixture()
+async def position():
+    return Position(position_data)
 
 
 @pytest.fixture()

--- a/tests/test_fpl.py
+++ b/tests/test_fpl.py
@@ -7,6 +7,7 @@ from fpl.models.fixture import Fixture
 from fpl.models.gameweek import Gameweek
 from fpl.models.h2h_league import H2HLeague
 from fpl.models.player import Player, PlayerSummary
+from fpl.models.position import Position
 from fpl.models.team import Team
 from fpl.models.user import User
 from tests.helper import AsyncMock
@@ -143,6 +144,31 @@ class TestFPL:
         players = await fpl.get_players([1, 2, 3], True)
         assert len(players) == 3
         assert isinstance(players[0].fixtures, list)
+
+    @pytest.mark.asyncio
+    async def test_position(self, fpl):
+        # test invalid ID
+        with pytest.raises(ValueError):
+            await fpl.get_position(-1)
+
+        position = await fpl.get_position(1)
+        assert isinstance(position, Position)
+
+        position = await fpl.get_position(1, return_json=True)
+        assert isinstance(position, dict)
+
+    @pytest.mark.asyncio
+    async def test_positions(self, fpl):
+        positions = await fpl.get_positions()
+        assert isinstance(positions, list)
+        assert isinstance(positions[0], Position)
+
+        positions = await fpl.get_positions(return_json=True)
+        assert isinstance(positions, list)
+        assert isinstance(positions[0], dict)
+
+        positions = await fpl.get_positions([1, 2, 3])
+        assert len(positions) == 3
 
     @pytest.mark.asyncio
     async def test_fixture(self, fpl):

--- a/tests/test_position.py
+++ b/tests/test_position.py
@@ -1,0 +1,31 @@
+from fpl.models import Position
+
+position_data = {
+    "id": 1,
+    "plural_name": "Goalkeepers",
+    "plural_name_short": "GKP",
+    "singular_name": "Goalkeeper",
+    "singular_name_short": "GKP",
+    "squad_select": 2,
+    "squad_min_select": None,
+    "squad_max_select": None,
+    "squad_min_play": 1,
+    "squad_max_play": 1,
+    "ui_shirt_specific": True,
+    "sub_positions_locked": [
+        12
+    ],
+    "element_count": 64
+}
+
+
+class TestPosition:
+    @staticmethod
+    def test_init():
+        position = Position(position_data)
+        for k, v in position_data.items():
+            assert getattr(position, k) == v
+
+    @staticmethod
+    def test_str(position):
+        assert str(position) == "Goalkeeper"


### PR DESCRIPTION
_Description of changes:_
- Added a `Position` model to the models.
- Added `get_position` and `get_positions` methods. These methods are very simple and only use the data returned from the `/api/bootstrap-static/` endpoint.
- Added unit tests for the model and FPL methods.
- Added documentation for the `Position` model.