### PR TITLE
Bug - Fix team converters returning incorrect mapping

### DIFF
--- a/fpl/fpl.py
+++ b/fpl/fpl.py
@@ -261,7 +261,8 @@ class FPL:
         if return_json:
             return player
 
-        return Player(player, self.session)
+        teams_json = await self.get_teams(return_json=True)
+        return Player(player, self.session, teams_json)
 
     async def get_players(self, player_ids=None, include_summary=False,
                           return_json=False):
@@ -397,7 +398,8 @@ class FPL:
         if return_json:
             return fixture
 
-        return Fixture(fixture)
+        teams_json = await self.get_teams(return_json=True)
+        return Fixture(fixture, teams_json)
 
     async def get_fixtures_by_id(self, fixture_ids, return_json=False):
         """Returns a list of all fixtures with IDs included in the
@@ -434,7 +436,8 @@ class FPL:
         if return_json:
             return fixtures
 
-        return [Fixture(fixture) for fixture in fixtures]
+        teams_json = await self.get_teams(return_json=True)
+        return [Fixture(fixture, teams_json) for fixture in fixtures]
 
     async def get_fixtures_by_gameweek(self, gameweek, return_json=False):
         """Returns a list of all fixtures of the given ``gameweek``.
@@ -457,7 +460,8 @@ class FPL:
         if return_json:
             return fixtures
 
-        return [Fixture(fixture) for fixture in fixtures]
+        teams_json = await self.get_teams(return_json=True)
+        return [Fixture(fixture, teams_json) for fixture in fixtures]
 
     async def get_fixtures(self, return_json=False):
         """Returns a list of *all* fixtures.
@@ -477,7 +481,8 @@ class FPL:
         if return_json:
             return fixtures
 
-        return [Fixture(fixture) for fixture in fixtures]
+        teams_json = await self.get_teams(return_json=True)
+        return [Fixture(fixture, teams_json) for fixture in fixtures]
 
     async def get_gameweek(self, gameweek_id, include_live=False,
                            return_json=False):
@@ -717,7 +722,10 @@ class FPL:
                     continue
 
                 points = fixture["total_points"]
-                opponent = team_converter(fixture["opponent_team"])
+                opponent = team_converter(
+                    fixture["opponent_team"],
+                    await self.get_teams(return_json=True)
+                )
                 location = "H" if fixture["was_home"] else "A"
 
                 points_against.setdefault(

--- a/fpl/models/fixture.py
+++ b/fpl/models/fixture.py
@@ -12,7 +12,8 @@ def add_player(location, information):
 class Fixture:
     """A class representing a fixture in Fantasy Premier League."""
 
-    def __init__(self, fixture_information):
+    def __init__(self, fixture_information, teams_json=None):
+        self._teams_json = teams_json
         for k, v in fixture_information.items():
             if k == "stats":
                 v = {w["identifier"]: {"a": w["a"], "h": w["h"]} for w in v}
@@ -168,6 +169,6 @@ class Fixture:
             return {"a": [], "h": []}
 
     def __str__(self):
-        return (f"{team_converter(self.team_h)} vs. "
-                f"{team_converter(self.team_a)} - "
+        return (f"{team_converter(self.team_h, self._teams_json)} vs. "
+                f"{team_converter(self.team_a, self._teams_json)} - "
                 f"{date_formatter(self.kickoff_time)}")

--- a/fpl/models/player.py
+++ b/fpl/models/player.py
@@ -5,8 +5,9 @@ from ..utils import fetch, position_converter, team_converter
 class Player():
     """A class representing a player in Fantasy Premier League."""
 
-    def __init__(self, player_information, session):
+    def __init__(self, player_information, session, teams_json=None):
         self._session = session
+        self._teams_json = teams_json
         for k, v in player_information.items():
             setattr(self, k, v)
 
@@ -55,7 +56,7 @@ class Player():
     def __str__(self):
         return (f"{self.web_name} - "
                 f"{position_converter(self.element_type)} - "
-                f"{team_converter(self.team)}")
+                f"{team_converter(self.team, self._teams_json)}")
 
 
 class PlayerSummary:

--- a/fpl/utils.py
+++ b/fpl/utils.py
@@ -83,60 +83,26 @@ async def get_current_gameweek(session):
     return current_gameweek["id"]
 
 
-def team_converter(team_id):
+def team_converter(team_id, teams):
     """Converts a team's ID to their actual name."""
-    team_map = {
-        1: "Arsenal",
-        2: "Aston Villa",
-        3: "Bournemouth",
-        4: "Brentford",
-        5: "Brighton",
-        6: "Burnley",
-        7: "Chelsea",
-        8: "Crystal Palace",
-        9: "Everton",
-        10: "Fulham",
-        11: "Liverpool",
-        12: "Luton",
-        13: "Man City",
-        14: "Man Utd",
-        15: "Newcastle",
-        16: "Nott'm Forest",
-        17: "Sheffield United",
-        18: "Spurs",
-        19: "West Ham",
-        20: "Wolves",
-        None: None
-    }
+    if not teams:
+        return "[Unknown]"
+
+    team_map = {}
+    for team in teams:
+        team_map[team["id"]] = team["name"]
     return team_map[team_id]
 
 
-def short_name_converter(team_id):
+def short_name_converter(team_id, teams):
     """Converts a team's ID to their short name."""
-    short_name_map = {
-        1: "ARS",
-        2: "AVL",
-        3: "BOU",
-        4: "BRE",
-        5: "BHA",
-        6: "BUR",
-        7: "CHE",
-        8: "CRY",
-        9: "EVE",
-        10: "FUL",
-        11: "LIV",
-        12: "LUT",
-        13: "MCI",
-        14: "MUN",
-        15: "NEW",
-        16: "NFO",
-        17: "SHU",
-        18: "TOT",
-        19: "WHU",
-        20: "WOL",
-        None: None
-    }
-    return short_name_map[team_id]
+    if not teams:
+        return "[Unknown]"
+
+    team_map = {}
+    for team in teams:
+        team_map[team["id"]] = team["short_name"]
+    return team_map[team_id]
 
 
 def position_converter(position):

--- a/tests/test_fixture.py
+++ b/tests/test_fixture.py
@@ -620,7 +620,3 @@ class TestFixture:
 
     def test_get_bps_finished(self, fixture):
         self._do_test_finished(fixture, "get_bps")
-
-    @staticmethod
-    def test_str(fixture):
-        assert str(fixture) == "Nott'm Forest vs. Bournemouth - Fri 20 Sep 19:00"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,8 +13,9 @@ class TestUtils:
     @pytest.mark.asyncio
     async def test_team_converter(self, fpl):
         teams = await fpl.get_teams()
+        teams_json = await fpl.get_teams(return_json=True)
         for team in teams:
-            assert team_converter(team.id) == team.name
+            assert team_converter(team.id, teams_json) == team.name
 
     @staticmethod
     def test_position_converter():


### PR DESCRIPTION
_Description of changes_

- Rather than rely on a hard-coded team mapping, use the `get_teams` function to dynamically create the team converter mapping.